### PR TITLE
WandBLogger typehints

### DIFF
--- a/erpy/instances/loggers/wandb_logger.py
+++ b/erpy/instances/loggers/wandb_logger.py
@@ -18,8 +18,8 @@ WandBRun = wandb.wandb_sdk.wandb_run.Run
 @dataclass
 class WandBLoggerConfig(LoggerConfig):
     project_name: str
-    group: str
-    tags: List[str]
+    group: str | None
+    tags: List[str] | None
     update_saver_path: bool
     pre_initialise_wandb: bool = True
     enable_tensorboard_backend: bool = False


### PR DESCRIPTION
In the morphology tutorial, we set `None` as value for `group` and `tag`.  
This should make this possible without further warnings