### PR TITLE
fix wrong typehint for `run`

### DIFF
--- a/erpy/instances/loggers/wandb_logger.py
+++ b/erpy/instances/loggers/wandb_logger.py
@@ -7,14 +7,13 @@ from typing import List, Type, Union, Any, Iterable, Optional
 import numpy as np
 import wandb
 from wandb.sdk.lib import RunDisabled
-from wandb.sdk.wandb_run import Run
 
 from erpy.framework.ea import EAConfig
 from erpy.framework.logger import Logger, LoggerConfig
 from erpy.framework.population import Population
 from erpy.utils.config2json import config2dict
 
-WandBRun = wandb.wandb_sdk.wandb_run.Run
+WandBRun = Union[Optional[wandb.wandb_sdk.wandb_run.Run, RunDisabled]]
 
 
 @dataclass
@@ -60,7 +59,7 @@ def wandb_log_unknown(run: WandBRun, name: str, data: Any, step: int) -> None:
 
 class WandBLogger(Logger):
 
-    run: Optional[Union[Run, RunDisabled]]
+    run: WandBRun
 
     def __init__(self, config: EAConfig):
         super().__init__(config=config)

--- a/erpy/instances/loggers/wandb_logger.py
+++ b/erpy/instances/loggers/wandb_logger.py
@@ -13,7 +13,7 @@ from erpy.framework.logger import Logger, LoggerConfig
 from erpy.framework.population import Population
 from erpy.utils.config2json import config2dict
 
-WandBRun = Union[Optional[wandb.wandb_sdk.wandb_run.Run, RunDisabled]]
+WandBRun = Optional[Union[wandb.wandb_sdk.wandb_run.Run, RunDisabled]]
 
 
 @dataclass


### PR DESCRIPTION
Just setting the type on 1 place created some issues.
The fix should be to change the type that was already used on multiple places.
This should be right since it was already possible that `run` was also `None` or `RunDisabled`, Dries seems to have ignored this